### PR TITLE
Step13

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
 	// redisson
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	implementation ("org.redisson:redisson-spring-boot-starter:3.23.5")
+	testImplementation("it.ozimov:embedded-redis:0.7.2")
 	// cache
 	implementation ("org.springframework.boot:spring-boot-starter-cache")
 }

--- a/src/main/java/kr/hhplus/be/server/application/reservation/ReservationFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/reservation/ReservationFacade.java
@@ -5,6 +5,7 @@ import kr.hhplus.be.server.domain.payment.PaymentInfo;
 import kr.hhplus.be.server.domain.payment.PaymentService;
 import kr.hhplus.be.server.domain.payment.PaymentType;
 import kr.hhplus.be.server.domain.point.PointService;
+import kr.hhplus.be.server.domain.ranking.RankingService;
 import kr.hhplus.be.server.domain.reservation.ReservationInfo;
 import kr.hhplus.be.server.domain.reservation.ReservationService;
 import kr.hhplus.be.server.domain.seat.SeatService;
@@ -25,6 +26,7 @@ public class ReservationFacade {
     private final PaymentService paymentService;
     private final SeatService seatService;
     private final RedisLock redisLock;
+    private final RankingService rankingService;
 
     public ReservationInfo reserveConcert(ReserveConcertCommand reserveConcertCommand){
         String lockKey = "lock:seat:" + reserveConcertCommand.seatId();
@@ -38,7 +40,7 @@ public class ReservationFacade {
         try {
             seatService.reserveSeat(reserveConcertCommand.seatId());
             ReservationInfo reservationInfo = reservationService.createReservation(reserveConcertCommand.userId(), reserveConcertCommand.seatId());
-            log.info("예약은 성공");
+            rankingService.addConcertRankingScore(reserveConcertCommand.concertId());
             return processReservationTransaction(reserveConcertCommand, reservationInfo);
 
         }catch (IllegalArgumentException illegalArgumentException){

--- a/src/main/java/kr/hhplus/be/server/application/reservation/ReserveConcertCommand.java
+++ b/src/main/java/kr/hhplus/be/server/application/reservation/ReserveConcertCommand.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.application.reservation;
 
 public record ReserveConcertCommand(
+        long concertId,
         long userId,
         long seatId,
         long seatPrice

--- a/src/main/java/kr/hhplus/be/server/domain/ranking/Ranking.java
+++ b/src/main/java/kr/hhplus/be/server/domain/ranking/Ranking.java
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.domain.ranking;
+
+public record Ranking(
+        long rank,
+        long concertId,
+        String concertName
+) {
+}

--- a/src/main/java/kr/hhplus/be/server/domain/ranking/RankingConcert.java
+++ b/src/main/java/kr/hhplus/be/server/domain/ranking/RankingConcert.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.domain.ranking;
+
+public record RankingConcert(
+        long concertId,
+        String concertName
+) {
+}

--- a/src/main/java/kr/hhplus/be/server/domain/ranking/RankingRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/ranking/RankingRepository.java
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.domain.ranking;
+
+import java.time.Duration;
+import java.util.List;
+
+public interface RankingRepository {
+    void addRankingScore(String key, double score, String member);
+    List<String> getTopMembersByScoreDesc(String key);
+    void saveRankingInfo(String key, List<String> rankingList, Duration ttl);
+    void unionAndStoreRanking(List<String> sourceKeys, String targetKey, Duration ttl);
+    List<String> getRankingInfo(String key);
+}

--- a/src/main/java/kr/hhplus/be/server/domain/ranking/RankingService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/ranking/RankingService.java
@@ -1,0 +1,134 @@
+package kr.hhplus.be.server.domain.ranking;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.domain.concert.Concert;
+import kr.hhplus.be.server.domain.concert.ConcertRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RankingService {
+
+    private final RankingRepository rankingRepository;
+    private final ConcertRepository concertRepository;
+    private final ObjectMapper objectMapper;
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    public void addConcertRankingScore(long concertId){
+        String todayKey = "concert:ranking:" + LocalDate.now().format(formatter);
+        rankingRepository.addRankingScore(todayKey, 1, String.valueOf(concertId));
+    }
+
+    public void setAggregateRanking(int days, String targetKey){
+
+        // 어제까지 N일 전까지 key 수집 ["concert:ranking:20250501", "concert:ranking:20250502"....]
+        List<String> keys = generateKeys(days);
+        // 1. Redis ZUNIONSTORE로 합산 (임시 key 사용 후 삭제) -> score 합산
+        unionAndStoreRanking(keys, targetKey, 1l);
+        // 2. 점수 기준 내림차순 정렬된 콘서트 ID 리스트 가져오기
+        List<Long> concertIds = getRankedConcertIds(targetKey);
+        if (concertIds.isEmpty()) {
+            log.info("No concert ranking data for {}", targetKey);
+            return;
+        }
+        // 3. 콘서트 정보 조회 & JSON 변환
+        List<String> rankingJsonList = concertRankingJson(concertIds);
+        // 4. Redis List 저장
+        saveRankingResult(targetKey, rankingJsonList);
+
+    }
+
+    private List<String> generateKeys(int days){
+        LocalDate today = LocalDate.now();
+        List<String> keys = new ArrayList<>();
+
+        for (int i = days; i >= 1; i--) {
+            keys.add("concert:ranking:" + today.minusDays(i).format(formatter));
+        }
+        return keys;
+    }
+
+    private void unionAndStoreRanking(List<String> sourceKeys, String targetKey, long ttlDays){
+        rankingRepository.unionAndStoreRanking(sourceKeys, targetKey, Duration.ofDays(ttlDays));
+    }
+
+    private List<Long> getRankedConcertIds(String targetKey){
+        List<String> topMembersByScoreDesc = rankingRepository.getTopMembersByScoreDesc(targetKey);
+        List<Long> concertIds = topMembersByScoreDesc.stream()
+                .map(Long::parseLong)
+                .collect(Collectors.toList());
+
+        return concertIds;
+    }
+
+    private List<String> concertRankingJson(List<Long> concertIds) {
+        List<Concert> concerts = concertRepository.findAllByIdIn(concertIds);
+        Map<Long, Concert> concertMap = concerts.stream()
+                .collect(Collectors.toMap(Concert::getId, Function.identity()));
+
+        List<String> jsonList = new ArrayList<>();
+        for (Long id : concertIds) {
+            Concert concert = concertMap.get(id);
+            if (concert == null) continue;
+
+            Map<String, Object> data = Map.of(
+                    "concertId", concert.getId(),
+                    "concertName", concert.getConcertName()
+            );
+
+            try {
+                jsonList.add(objectMapper.writeValueAsString(data));
+            } catch (JsonProcessingException e) {
+                log.error("Json 직렬화 오류: {}", concert.getId(), e);
+            }
+        }
+        return jsonList;
+    }
+
+    private void saveRankingResult(String key, List<String> jsonList) {
+        rankingRepository.saveRankingInfo(key, jsonList, Duration.ofDays(1));
+    }
+
+    public List<Ranking> concertRanking(String rankingType) {
+        String redisKey = getRedisKey(rankingType);
+
+        List<String> rankingJsonList = rankingRepository.getRankingInfo(redisKey);
+        if (rankingJsonList == null || rankingJsonList.isEmpty()) {
+            log.info("No ranking data found for key: {}", redisKey);
+            return Collections.emptyList();
+        }
+
+        List<Ranking> result = new ArrayList<>();
+        int rank = 1;
+        for (String json : rankingJsonList) {
+            try {
+                RankingConcert data = objectMapper.readValue(json, RankingConcert.class);
+                result.add(new Ranking(rank++, data.concertId(), data.concertName()));
+            } catch (JsonProcessingException e) {
+                log.error("JSON 역직렬화 실패: {}", json, e);
+            }
+        }
+        return result;
+    }
+
+    private String getRedisKey(String rankingType) {
+        return switch (rankingType) {
+            case "daily" -> "concert:ranking:daily";
+            case "weekly" -> "concert:ranking:weekly";
+            case "monthly" -> "concert:ranking:monthly";
+            default -> throw new IllegalArgumentException("Unknown ranking type: " + rankingType);
+        };
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infra/concert/ConcertRepositoryCustom.java
+++ b/src/main/java/kr/hhplus/be/server/infra/concert/ConcertRepositoryCustom.java
@@ -9,4 +9,5 @@ import java.util.List;
 
 public interface ConcertRepositoryCustom {
     List<Concert> findAllConcerts();
+    List<Concert> findAllByIdIn(List<Long> concertIds);
 }

--- a/src/main/java/kr/hhplus/be/server/infra/concert/ConcertRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/concert/ConcertRepositoryImpl.java
@@ -11,6 +11,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -28,4 +32,13 @@ public class ConcertRepositoryImpl implements ConcertRepositoryCustom {
         return result;
     }
 
+    @Override
+    public List<Concert> findAllByIdIn(List<Long> concertIds) {
+        QConcert concert = QConcert.concert;
+        List<Concert> concerts = queryFactory
+                .selectFrom(concert)
+                .where(concert.id.in(concertIds)) // 순서 보장하지 않음
+                .fetch();
+        return concerts;
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/infra/redis/RedisRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/redis/RedisRepository.java
@@ -1,0 +1,64 @@
+package kr.hhplus.be.server.infra.redis;
+
+import kr.hhplus.be.server.domain.ranking.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RList;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.*;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisRepository implements RankingRepository {
+
+    private final RedissonClient redissonClient;
+    @Override
+    public void addRankingScore(String key, double score, String member){
+        RScoredSortedSet<String> zSet = redissonClient.getScoredSortedSet(key, StringCodec.INSTANCE);
+        zSet.addScore(member, score);
+//        ttl 없을 시 추가
+        if(zSet.remainTimeToLive() == -1){
+            zSet.expire(Duration.ofDays(30));
+        }
+    }
+
+    @Override
+    public List<String> getTopMembersByScoreDesc(String key){
+        RScoredSortedSet<String> zSet = redissonClient.getScoredSortedSet(key, StringCodec.INSTANCE);
+        Collection<String> range = zSet.valueRangeReversed(0, -1);
+        return new ArrayList<>(range);
+    }
+
+    @Override
+    public void saveRankingInfo(String key, List<String> rankingList, Duration ttl) {
+        RList<String> redisList = redissonClient.getList(key, StringCodec.INSTANCE);
+        redisList.clear();
+        redisList.addAll(rankingList);
+        redisList.expire(ttl);
+    }
+
+    @Override
+    public void unionAndStoreRanking(List<String> sourceKeys, String targetKey, Duration ttl) {
+        // 소스로 사용하는 keys 가 없으면 취소
+        if (sourceKeys == null || sourceKeys.isEmpty()) return;
+
+        String[] keysArray = sourceKeys.toArray(new String[0]);
+        RScoredSortedSet<String> zSet = redissonClient.getScoredSortedSet(targetKey, StringCodec.INSTANCE);
+        // Redis에서 기존 key 삭제 (중복 방지)
+        zSet.clear();
+        // ZUNIONSTORE: 점수 합산
+        zSet.union(keysArray);
+        zSet.expire(ttl);
+    }
+
+    @Override
+    public List<String> getRankingInfo(String key) {
+        RList<String> rankingList = redissonClient.getList(key);
+        return rankingList.readAll();
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/ranking/RankingApi.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/ranking/RankingApi.java
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.interfaces.ranking;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Tag(name = "랭킹 조회 api")
+@RequestMapping("/ranking")
+public interface RankingApi {
+
+    @GetMapping("/{rankingType}")
+    default ResponseEntity<List<ResponseRankingDTO>> concertRanking(@PathVariable("rankingType") String rankingType){
+        List<ResponseRankingDTO> mockResponse = List.of(
+                new ResponseRankingDTO(1, 1, "Concert A"),
+                new ResponseRankingDTO(2, 2, "Concert B")
+                );
+        return ResponseEntity.ok(mockResponse);
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/ranking/RankingController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/ranking/RankingController.java
@@ -1,0 +1,27 @@
+package kr.hhplus.be.server.interfaces.ranking;
+
+import kr.hhplus.be.server.domain.ranking.Ranking;
+import kr.hhplus.be.server.domain.ranking.RankingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/ranking")
+@RequiredArgsConstructor
+public class RankingController implements RankingApi {
+
+    private final RankingService rankingService;
+
+    @GetMapping("/{rankingType}")
+    @Override
+    public ResponseEntity<List<ResponseRankingDTO>> concertRanking(@PathVariable("rankingType") String rankingType){
+        List<Ranking> rankingList = rankingService.concertRanking(rankingType.toLowerCase());
+        List<ResponseRankingDTO> result = rankingList.stream().map(
+                ranking -> ResponseRankingDTO.from(ranking)).toList();
+        return ResponseEntity.ok(result);
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/ranking/ResponseRankingDTO.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/ranking/ResponseRankingDTO.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.interfaces.ranking;
+
+import kr.hhplus.be.server.domain.concert.Concert;
+import kr.hhplus.be.server.domain.ranking.Ranking;
+import kr.hhplus.be.server.interfaces.concert.response.ConcertResponseDTO;
+
+public record ResponseRankingDTO(
+        long rank,
+        long concertId,
+        String concertName
+) {
+    public static ResponseRankingDTO from(Ranking ranking){
+        return new ResponseRankingDTO(ranking.rank(), ranking.concertId(), ranking.concertName());
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/reservation/ReservationController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/reservation/ReservationController.java
@@ -22,11 +22,9 @@ public class ReservationController implements ReservationApi{
     @Override
     @PostMapping("/reserve")
     public ResponseEntity<ReserveResponseDTO> reserveConcert(@RequestBody ReserveRequestDTO reqeust){
-        ReserveConcertCommand command = new ReserveConcertCommand(reqeust.userId(), reqeust.seatId(), reqeust.seatPrice());
+        ReserveConcertCommand command = new ReserveConcertCommand(reqeust.concertId(), reqeust.userId(), reqeust.seatId(), reqeust.seatPrice());
         ReservationInfo reservationInfo = reservationFacade.reserveConcert(command);
         ReserveResponseDTO result = new ReserveResponseDTO(reservationInfo.reservationId(), reservationInfo.userId(), reservationInfo.seatId(), reservationInfo.reservationStatus().toString());
         return ResponseEntity.ok(result);
     }
-
-
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/reservation/request/ReserveRequestDTO.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/reservation/request/ReserveRequestDTO.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.interfaces.reservation.request;
 
 public record ReserveRequestDTO(
+        long concertId,
         long userId,
         long seatId,
         long seatPrice

--- a/src/main/java/kr/hhplus/be/server/interfaces/scheduler/Scheduler.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/scheduler/Scheduler.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.interfaces.scheduler;
 
 import kr.hhplus.be.server.domain.queue.WaitingQueueService;
+import kr.hhplus.be.server.domain.ranking.RankingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -13,9 +14,18 @@ import java.time.LocalDateTime;
 public class Scheduler {
 
     private final WaitingQueueService waitingQueueService;
+    private final RankingService rankingService;
 
     @Scheduled(fixedRateString = "${scheduler.fix-rate-ms}")
     public void runScheduler(){
         waitingQueueService.refreshWaitingQueueStatus(LocalDateTime.now());
     }
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 00시
+    public void rankingScheduler() {
+        rankingService.setAggregateRanking(1, "concert:ranking:daily");
+        rankingService.setAggregateRanking(7, "concert:ranking:weekly");
+        rankingService.setAggregateRanking(30, "concert:ranking:monthly");
+    }
+
 }

--- a/src/main/java/kr/hhplus/be/server/support/redis/RedisService.java
+++ b/src/main/java/kr/hhplus/be/server/support/redis/RedisService.java
@@ -1,13 +1,27 @@
 package kr.hhplus.be.server.support.redis;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RSortedSet;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.client.protocol.ScoredEntry;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RedisService {
-
+    private final RedissonClient redissonClient;
     private final RedisTemplate<String, Object> redisTemplate;
 
     public void save(String key, String value){
@@ -27,4 +41,24 @@ public class RedisService {
         redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
     }
 
+    public void zAdd(String key, long score, String member){
+        /*
+        * redisson RSortedSet ->redis 자료형 list, set
+        * redisson RScoreSortedSet -> redis 자료현 zSet
+        * codec 설정을 해줘야지 직렬화 없이 string으로 저장
+        * */
+        RScoredSortedSet<String> zSet = redissonClient.getScoredSortedSet(key, StringCodec.INSTANCE);
+
+        zSet.add(score, member); // member의 score를 update(없으면 생성)
+    }
+
+    public double zIncrBy(String key, double score, String member ){
+        RScoredSortedSet<String> zSet = redissonClient.getScoredSortedSet(key, StringCodec.INSTANCE);
+        return zSet.addScore(member,score); //member의 score를 추가
+    }
+
+     public Collection<ScoredEntry<String>> zRangeByScore(String key){
+        RScoredSortedSet<String> zSets = redissonClient.getScoredSortedSet(key, StringCodec.INSTANCE);
+        return zSets.entryRange(0,-1);
+    }
 }

--- a/src/test/java/kr/hhplus/be/server/RedisServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/RedisServiceTest.java
@@ -1,20 +1,36 @@
 package kr.hhplus.be.server;
 
 import kr.hhplus.be.server.support.redis.RedisService;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.redisson.Redisson;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
+import org.redisson.client.protocol.ScoredEntry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Random;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Slf4j
 public class RedisServiceTest {
 
     @Autowired
     private RedisService redisService;
+
+    @Autowired
+    private RedissonClient redissonClient;
 
     @Test
     void redisRegisterStrings(){
@@ -38,6 +54,36 @@ public class RedisServiceTest {
         Object result = redisService.get(key);
 
         assertThat(result).isNull();
+    }
+
+    @Test
+    void redissonZAdd(){
+        LocalDate now = LocalDate.now();
+        DateTimeFormatter ofPattern = DateTimeFormatter.ofPattern("yyyyMMdd");
+        String key = "concert:" + now.format(ofPattern);
+        int count = 10;
+        Random random = new Random();
+        for(int i = 1; i < count; i ++){
+            String member = "item" + i;
+            int number = random.nextInt(10) + 1;
+            redisService.zAdd(key, number, member);
+        }
+
+        Collection<ScoredEntry<String>> zSets = redisService.zRangeByScore(key);
+        zSets.stream().forEach(zset -> log.info("member : {}, score : {}", zset.getValue(), zset.getScore()));
+    }
+
+    @Test
+    void zIncrBy(){
+        String key = "concert:20250513";
+        String member = "item4";
+        double score = 12;
+
+        double updatedScore = redisService.zIncrBy(key,score, member);
+
+        RScoredSortedSet<String> zSets = redissonClient.getScoredSortedSet(key, StringCodec.INSTANCE);
+
+        assertThat(zSets.getScore(member)).isEqualTo(updatedScore);
     }
 
 }

--- a/src/test/java/kr/hhplus/be/server/application/reservation/ReservationFacadeConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/reservation/ReservationFacadeConcurrencyTest.java
@@ -82,7 +82,7 @@ class ReservationFacadeConcurrencyTest {
             executorService.submit(()->{
                 try {
                     startLatch.await();
-                    ReserveConcertCommand command = new ReserveConcertCommand(userId, savedSeat.getId(), seatPrice);
+                    ReserveConcertCommand command = new ReserveConcertCommand(1l, userId, savedSeat.getId(), seatPrice);
                     reservationFacade.reserveConcert(command);
                 } catch (Exception e) {
                     log.error("예약 실패 : {}",e.getMessage());

--- a/src/test/java/kr/hhplus/be/server/application/reservation/ReservationFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/reservation/ReservationFacadeIntegrationTest.java
@@ -65,8 +65,8 @@ class ReservationFacadeIntegrationTest {
     @DisplayName("콘서트_예약_잔액_부족_예약_내역만_생성")
     void reserveConcert_insufficient() {
         long userId = 1l;
-
-        ReserveConcertCommand command = new ReserveConcertCommand(userId, savedSeat.getId(), savedSeat.getConcertSeatPrice());
+        long concertId = 1l;
+        ReserveConcertCommand command = new ReserveConcertCommand(concertId, userId, savedSeat.getId(), savedSeat.getConcertSeatPrice());
 
         ReservationInfo info = reservationFacade.reserveConcert(command);
 
@@ -82,9 +82,10 @@ class ReservationFacadeIntegrationTest {
     void reserveConcert() {
         long userId = 1l;
         long chargePoint = 3000l;
+        long concertId = 2l;
         pointService.chargeUserPoint(userId,chargePoint);
 
-        ReserveConcertCommand command = new ReserveConcertCommand(userId, savedSeat.getId(), savedSeat.getConcertSeatPrice());
+        ReserveConcertCommand command = new ReserveConcertCommand(concertId, userId, savedSeat.getId(), savedSeat.getConcertSeatPrice());
 
         ReservationInfo info = reservationFacade.reserveConcert(command);
 
@@ -102,9 +103,10 @@ class ReservationFacadeIntegrationTest {
     void processReservationTransaction_success() {
         long userId = 1L;
         long seatPrice = 3000L;
+        long concertId = 1l;
         PointInfo initialPoint = pointService.getUserPoint(userId);
         pointService.chargeUserPoint(userId, seatPrice);
-        ReserveConcertCommand command = new ReserveConcertCommand(userId, savedSeat.getId(), savedSeat.getConcertSeatPrice());
+        ReserveConcertCommand command = new ReserveConcertCommand(concertId,userId, savedSeat.getId(), savedSeat.getConcertSeatPrice());
         ReservationInfo reservationInfo = reservationService.createReservation(savedSeat.getId(), userId);
         List<PaymentInfo> paymentsBefore = paymentService.getUserPaymentList(userId);
         long initialPaymentSize = paymentsBefore.size();

--- a/src/test/java/kr/hhplus/be/server/application/reservation/ReservationFacadeLockTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/reservation/ReservationFacadeLockTest.java
@@ -83,7 +83,7 @@ public class ReservationFacadeLockTest {
             long newUserId = i + 1;
             executorService.submit(()->{
                try{
-                   reserveConcertCommand = new ReserveConcertCommand(newUserId,seatId, seatPrice);
+                   reserveConcertCommand = new ReserveConcertCommand(1l,newUserId,seatId, seatPrice);
                    reservationInfo = reservationFacade.reserveConcert(reserveConcertCommand);
                }catch (Exception e){
                    failCnt.getAndIncrement();

--- a/src/test/java/kr/hhplus/be/server/domain/ranking/RankingServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/ranking/RankingServiceTest.java
@@ -1,0 +1,93 @@
+package kr.hhplus.be.server.domain.ranking;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.domain.concert.Concert;
+import kr.hhplus.be.server.domain.concert.ConcertRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class RankingServiceTest {
+
+    @InjectMocks
+    private RankingService rankingService;
+
+    @Mock
+    private RankingRepository rankingRepository;
+
+    @Mock
+    private ConcertRepository concertRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Test
+    void testSetAggregateRanking() throws Exception {
+        // given
+        String targetKey = "concert:ranking:weekly";
+        List<String> redisKeys = List.of("concert:ranking:20250506", "concert:ranking:20250507");
+        List<String> topMembers = List.of("1", "2");
+        Concert concert1 = Concert.create("Concert A", 50L);
+        Concert concert2 = Concert.create("Concert B", 60L);
+
+        ReflectionTestUtils.setField(concert1, "id", 1L);
+        ReflectionTestUtils.setField(concert2, "id", 2L);
+
+        List<Concert> concerts = List.of(concert1, concert2);
+
+        when(rankingRepository.getTopMembersByScoreDesc(targetKey)).thenReturn(topMembers);
+        when(concertRepository.findAllByIdIn(List.of(1L, 2L))).thenReturn(concerts);
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"concertId\":1,\"concertName\":\"Concert A\"}");
+
+        // when
+        rankingService.setAggregateRanking(2, targetKey);
+
+        // then
+        verify(rankingRepository).unionAndStoreRanking(anyList(), eq(targetKey), any());
+        verify(rankingRepository).saveRankingInfo(eq(targetKey), anyList(), any());
+    }
+
+    @Test
+    void testConcertRanking() throws Exception {
+        // given
+        String redisKey = "concert:ranking:weekly";
+        String json1 = "{\"concertId\":1,\"concertName\":\"Concert A\"}";
+        String json2 = "{\"concertId\":2,\"concertName\":\"Concert B\"}";
+
+        when(rankingRepository.getRankingInfo(redisKey)).thenReturn(List.of(json1, json2));
+        when(objectMapper.readValue(json1, RankingConcert.class))
+                .thenReturn(new RankingConcert(1L, "Concert A"));
+        when(objectMapper.readValue(json2, RankingConcert.class))
+                .thenReturn(new RankingConcert(2L, "Concert B"));
+
+        // when
+        List<Ranking> result = rankingService.concertRanking("weekly");
+
+        // then
+        assertEquals(2, result.size());
+        assertEquals("Concert A", result.get(0).concertName());
+        assertEquals(1L, result.get(0).concertId());
+        assertEquals(1, result.get(0).rank());
+    }
+
+    @Test
+    void testConcertRanking_withInvalidRankingType() {
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> {
+            rankingService.concertRanking("yearly");
+        });
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/interfaces/ranking/RankingControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/ranking/RankingControllerTest.java
@@ -1,0 +1,57 @@
+package kr.hhplus.be.server.interfaces.ranking;
+
+import kr.hhplus.be.server.domain.ranking.Ranking;
+import kr.hhplus.be.server.domain.ranking.RankingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+@WebMvcTest(controllers = RankingController.class)
+class RankingControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private RankingService rankingService;
+
+    @BeforeEach
+    void setUp(){
+        MockitoAnnotations.openMocks(this);
+
+    }
+
+    @DisplayName("콘서트_랭킹_일별_조회")
+    @Test
+    void concertRanking() throws Exception {
+        // given
+        List<Ranking> mockRankings = List.of(
+                new Ranking(1, 1001L, "콘서트 A"),
+                new Ranking(2, 1002L, "콘서트 B")
+        );
+        when(rankingService.concertRanking("daily")).thenReturn(mockRankings);
+
+        // when & then
+        mvc.perform(get("/ranking/daily"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].rank").value(1))
+                .andExpect(jsonPath("$[0].concertId").value(1001))
+                .andExpect(jsonPath("$[0].concertName").value("콘서트 A"))
+                .andExpect(jsonPath("$[1].rank").value(2))
+                .andExpect(jsonPath("$[1].concertId").value(1002))
+                .andExpect(jsonPath("$[1].concertName").value("콘서트 B"));
+        verify(rankingService, times(1)).concertRanking("daily");
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/interfaces/reservation/ReservationControllerTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/reservation/ReservationControllerTest.java
@@ -40,8 +40,8 @@ class ReservationControllerTest {
         long seatPrice = 50000L;
         long paymentId = 1l;
 
-        ReserveRequestDTO requestDTO = new ReserveRequestDTO(userId, seatId, seatPrice);
-        ReserveConcertCommand reserveConcertCommand = new ReserveConcertCommand(userId,seatId,seatPrice);
+        ReserveRequestDTO requestDTO = new ReserveRequestDTO(1l, userId, seatId, seatPrice);
+        ReserveConcertCommand reserveConcertCommand = new ReserveConcertCommand(1l,userId,seatId,seatPrice);
         ReservationInfo reservationInfo = new ReservationInfo(
                 100L, // reservationId
                 userId,


### PR DESCRIPTION
### **커밋 링크**


#29 
콘서트 랭킹 서비스
 - 랭킹 서비스, 레포지토리 추가 : 4a1760a
 - 랭킹 스케줄러 추가 : a4723e9
 - 예약 파사드에 랭킹 점수 추가 : 7570116
 - 랭킹 콘서트 정보 조회 쿼리 추가 : 032f51d
 - 랭킹 테스트 코드 추가 : 27f3881

리팩토링 및 테스트 코드 수정 사항
- 예약 dto, command 수정 : 0f860ce
- dto, command 수정으로 테스트 코드 수정 : 3cdc2b5
- 

<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

---
### **리뷰 포인트(질문)**
- 랭킹을 00시에 스케줄러로 쌓는방식으로 구현했습니다만 랭킹의 ttl을 1일로 잡아둬서 맞물리듯이 교체가 되어야한다고 생각됩니다. 맞물리듯이 교체가되는 방식이 에러나 예외상황에선 위험해보입니다. 그래서 랭킹의 ttl을 1일보다 조금 더 잡아둘지 아니면 다른 방식이 있는지가 궁금합니다.
- redis의 패키지 위치가 적절한지 고민이 됩니다.  ranking 도메인에 서비스를 위치시켜서 진행하였는데 이러한 위치가 적절한가요? 
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
- redis 자료구조를 학습하면서 일일이 테스트 해본점
### Problem
<!--개선이 필요한 점-->
- 자료구조 학습하는데 시간 할애가 많아서 실제로 기능 구현에 시간을 많이 못씀
- 테스트코드 작성을 더 세세히 하지 못한 점
### Try
<!-- 새롭게 시도할 점 -->
- Redis를 테스트할 때 redis-embedded를 추가하여 해보려고 한점(결국 실패 ...? 왜그렇지?)
- 새로운 기능을 추가할 때 테스트코드를 진행하면서 해본점(물론 세세하지 못했다...)